### PR TITLE
Replace uploader & downloader implementations with rclone and compress before upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pingcap/tidb-enterprise-tools:latest
 ARG VERSION=v1.48.0
 RUN apk update && apk add ca-certificates
 ADD backup.sh backup.sh
-# ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
+ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
 
 RUN \
   chmod 755 backup.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN \
   chmod 755 backup.sh \
   && cp backup.sh /usr/local/bin/uploader \
   && cp backup.sh /usr/local/bin/downloader \
+  && rm backup.sh \
   && wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
   && unzip rclone-${VERSION}-linux-amd64.zip \
   && mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin/rclone \
-  && chmod 755 /rclone \
-  && rm -rf rclone-${VERSION}-linux-amd64.zip
+  && apk add pigz \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm -rf rclone-${VERSION}-linux-amd64.zip \
+  && rm -rf rclone-${VERSION}-linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM pingcap/tidb-enterprise-tools:latest
 
+ARG VERSION=v1.48.0
 RUN apk update && apk add ca-certificates
-ADD bin/uploader /usr/local/bin/uploader
-ADD bin/downloader /usr/local/bin/downloader
-ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
+ADD backup.sh backup.sh
+# ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
+
+RUN \
+  chmod 755 backup.sh \
+  && cp backup.sh /usr/local/bin/uploader \
+  && cp backup.sh /usr/local/bin/downloader \
+  && wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
+  && unzip rclone-${VERSION}-linux-amd64.zip \
+  && mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin/rclone \
+  && chmod 755 /rclone \
+  && rm -rf rclone-${VERSION}-linux-amd64.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
 
 RUN \
   chmod 755 backup.sh \
-  && cp backup.sh /usr/local/bin/uploader \
-  && cp backup.sh /usr/local/bin/downloader \
-  && rm backup.sh \
+  && ln -s /backup.sh /usr/local/bin/uploader \
+  && ln -s /backup.sh /usr/local/bin/downloader \
   && wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
   && unzip rclone-${VERSION}-linux-amd64.zip \
   && mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin/rclone \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ADD backup.sh backup.sh
 ADD bin/etcdbackuper /usr/local/bin/etcdbackuper
 
 RUN \
-  chmod 755 backup.sh \
+  apk add pigz --no-cache \
+  && chmod 755 backup.sh \
   && ln -s /backup.sh /usr/local/bin/uploader \
   && ln -s /backup.sh /usr/local/bin/downloader \
   && wget -nv https://github.com/ncw/rclone/releases/download/${VERSION}/rclone-${VERSION}-linux-amd64.zip \
   && unzip rclone-${VERSION}-linux-amd64.zip \
   && mv rclone-${VERSION}-linux-amd64/rclone /usr/local/bin/rclone \
-  && apk add pigz \
   && chmod 755 /usr/local/bin/rclone \
   && rm -rf rclone-${VERSION}-linux-amd64.zip \
   && rm -rf rclone-${VERSION}-linux-amd64

--- a/backup.sh
+++ b/backup.sh
@@ -81,11 +81,14 @@ type = google cloud storage
 service_account_file = ${GOOGLE_APPLICATION_CREDENTIALS}
 EOF
 
+# In tidb-backup job downloader and uploader take different dir parameters
+# During uploading, the backup_dir is /<BASE_DIR>/<BACKUP_NAME>/, and the data will be uploaded to /<BACKUP_NAME>
+# During downloading, the backup_dir is /<BACKUP_NAME>/, and the data will be downloaded from /<BACKUP_NAME>
 export BACKUP_NAME=$(basename ${BACKUP_DIR})
 if [ "${RUN_MODE}" = "uploader" ]; then
   export BACKUP_BASE_DIR=$(dirname ${BACKUP_DIR})
   tar -cf - ${BACKUP_NAME} -C ${BACKUP_BASE_DIR} | pigz -p 16 > ${BACKUP_BASE_DIR}/${BACKUP_NAME}.tgz
-  rclone --config /tmp/rclone.conf copyto ${BACKUP_BASE_DIR}/${BACKUP_NAME}.tgz ${CLOUD}:${BUCKET}/${BACKUP_DIR}/${BACKUP_NAME}.tgz
+  rclone --config /tmp/rclone.conf copyto ${BACKUP_BASE_DIR}/${BACKUP_NAME}.tgz ${CLOUD}:${BUCKET}/${BACKUP_NAME}/${BACKUP_NAME}.tgz
   rm ${BACKUP_BASE_DIR}/${BACKUP_NAME}.tgz
 elif [ "$RUN_MODE" = "downloader" ]; then
   rclone --config /tmp/rclone.conf copyto ${CLOUD}:${BUCKET}/${BACKUP_DIR} ${DEST_DIR}

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -e -x
+
+export RUN_MODE=`basename "$0"`
+
+for i in "$@"
+do
+case $i in
+--cloud=*)
+  export CLOUD="${i#*=}"
+  shift
+  ;;
+--region=*)
+  export REGION="${i#*=}"
+  shift
+  ;;
+--bucket=*)
+  export BUCKET="${i#*=}"
+  shift
+  ;;
+--endpoint=*)
+  export ENDPOINT="${i#*=}"
+  shift
+  ;;
+--backup-dir=*|--srcDir=*)
+  export BACKUP_DIR="${i#*=}"
+  shift
+  ;;
+--destDir=*)
+  export DEST_DIR="${i#*=}"
+  shift
+  ;;
+  *)
+  common::log "unknown option [$i]"
+  exit 1
+  ;;
+esac
+
+done
+
+if [ "$CLOUD" = "gcp" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+  echo "GCP credentials path is not set"
+  exit 1
+fi
+
+if [ "$CLOUD" = "ceph" ] || [ "$CLOUD" = "aws" ]; then
+  if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "S3 access key is not set"
+    exit 1
+  fi
+  if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "S3 access secret is not set"
+    exit 1
+  fi
+fi
+
+cat <<EOF > /tmp/rclone.conf
+[aws]
+type = s3
+env_auth = false
+provider = ${S3_PROVIDER:-"AWS"}
+access_key_id = ${AWS_ACCESS_KEY_ID}
+secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+region = ${REGION}
+endpoint = ${ENDPOINT}
+[ceph]
+type = s3
+env_auth = false
+provider = ${S3_PROVIDER:-"Ceph"}
+access_key_id = ${AWS_ACCESS_KEY_ID}
+secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+region = :default-placement
+endpoint = ${ENDPOINT}
+[gcp]
+type = google cloud storage
+service_account_file = ${GOOGLE_APPLICATION_CREDENTIALS}
+EOF
+
+if [ "$RUN_MODE" = "uploader" ]; then
+  export BACKUP_BASE_DIR="$(dirname "$BACKUP_DIR")"
+  tar cvzf ${BACKUP_BASE_DIR}/backup.tgz -C ${BACKUP_BASE_DIR} $(basename "${BACKUP_DIR}")
+  rclone --config /tmp/rclone.conf copyto ${BACKUP_BASE_DIR}/backup.tgz ${CLOUD}:${BUCKET}/${BACKUP_DIR}/backup.tgz
+elif [ "$RUN_MODE" = "downloader" ]; then
+  rclone --config /tmp/rclone.conf copyto ${CLOUD}:${BUCKET}/${BACKUP_DIR} ${DEST_DIR}
+  if [ -f "$DEST_DIR/backup.tgz" ]; then
+    tar xzvf ${DEST_DIR}/backup.tgz -C ${DEST_DIR} && rm ${DEST_DIR}/backup.tgz
+  fi
+else
+  echo "Unknown run mode $RUN_MODE"
+  exit 1
+fi
+


### PR DESCRIPTION
@xiaojingchen @onlymellb @tennix @weekface  PTAL
Signed-off-by: Aylei <rayingecho@gmail.com>

Benchmark:

Environment: container runs in an AWS m4.xlarge instance (4C 16G) in tokyo with no resources limit. The data is uploaded to and download from S3 in US East Ohio.

Data size: 30.2 GB

**rclone implementation**:

Upload Time: 

* Compress: 17m 26s
* Upload: 15m 05s
* Total: 32m 32.74s

(Compressed size 14.5 GB)

Download Time:

* Download: 7m 42s
* Decompress: 10m 07s
* Total: 17m 40.09s

Resources Usage: 

* Compress: the container stably consumes 400% CPU and 11MB memory
* Upload: the container stably consumes 30% memory and 23MB memory, avg network tx 16.4MB/s

**Go implementation**:

Upload Time: 38m 10s
Download Time: 54m 47s

Tested upon s3 & ceph manually.

s3 log:
```
docker run -it --entrypoint sh aylei:test
/ # mkdir -p /data/backup/
/ # cd /data/backup
/data/backup # echo 111 > sql1
/data/backup # echo 222 > sql2
/data/backup # cd /
/ # uploader  --cloud=aws --region=us-east-2 --bucket=new-bucket-aylei --backup-dir=/data/backup
+ basename /usr/local/bin/uploader
+ export 'RUN_MODE=uploader'
+ export 'CLOUD=aws'
+ shift
+ export 'REGION=us-east-2'
+ shift
+ export 'BUCKET=new-bucket-aylei'
+ shift
+ export 'BACKUP_DIR=/data/backup'
+ shift
+ '[' aws '=' gcp ]
+ '[' aws '=' ceph ]
+ '[' aws '=' aws ]
+ '[' -z aaaa ]
+ '[' -z xxxxx ]
+ cat
+ '[' uploader '=' uploader ]
+ dirname /data/backup
+ export 'BACKUP_BASE_DIR=/data'
+ basename /data/backup
+ tar cvzf /data/backup.tgz -C /data backup
backup/
backup/sql1
backup/sql2
+ rclone --config /tmp/rclone.conf copyto /data/backup.tgz aws:new-bucket-aylei//data/backup/backup.tgz
/usr/local/bin/uploader: line 1: rclone: not found
/ # mv rclone /usr/local/bin/rclone
/ # uploader  --cloud=aws --region=us-east-2 --bucket=new-bucket-aylei --backup-dir=/data/backup
+ basename /usr/local/bin/uploader
+ export 'RUN_MODE=uploader'
+ export 'CLOUD=aws'
+ shift
+ export 'REGION=us-east-2'
+ shift
+ export 'BUCKET=new-bucket-aylei'
+ shift
+ export 'BACKUP_DIR=/data/backup'
+ shift
+ '[' aws '=' gcp ]
+ '[' aws '=' ceph ]
+ '[' aws '=' aws ]
+ '[' -z aaaaa ]
+ '[' -z ccccc ]
+ cat
+ '[' uploader '=' uploader ]
+ dirname /data/backup
+ export 'BACKUP_BASE_DIR=/data'
+ basename /data/backup
+ tar cvzf /data/backup.tgz -C /data backup
backup/
backup/sql1
backup/sql2
+ rclone --config /tmp/rclone.conf copyto /data/backup.tgz aws:new-bucket-aylei//data/backup/backup.tgz
/ # downloader --cloud=aws --region=us-east-2 --bucket=new-bucket-aylei --srcDir=/data/backup --destDir=/data
+ basename /usr/local/bin/downloader
+ export 'RUN_MODE=downloader'
+ export 'CLOUD=aws'
+ shift
+ export 'REGION=us-east-2'
+ shift
+ export 'BUCKET=new-bucket-aylei'
+ shift
+ export 'BACKUP_DIR=/data/backup'
+ shift
+ export 'DEST_DIR=/data'
+ shift
+ '[' aws '=' gcp ]
+ '[' aws '=' ceph ]
+ '[' aws '=' aws ]
+ '[' -z aaaaa ]
+ '[' -z ccccc ]
+ cat
+ '[' downloader '=' uploader ]
+ '[' downloader '=' downloader ]
+ rclone --config /tmp/rclone.conf copyto aws:new-bucket-aylei//data/backup /data
+ '[' -f /data/backup.tgz ]
+ tar xzvf /data/backup.tgz -C /data
backup/
backup/sql1
backup/sql2
+ rm /data/backup.tgz
/ # cd /data
/data # cd backup/
/data/backup # ls
sql1  sql2
```

Note that the new image can read the backup taken before, but the backup data taken by the new image cannot be properly de-compressed by the old image.

GCP test has not been done yet.